### PR TITLE
Update Pipfile.lock

### DIFF
--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -137,7 +137,7 @@
                 "sha256:d95ca4208046840e4af1fa3cfc915f2953b08e16c08cd4c4702c5a367ca45a72",
                 "sha256:e5167bade61ef3b15671e09b17589b246871822559762da3e01321f185a63286"
             ],
-            "index": "testpypi",
+            "index": "pypi",
             "version": "==0.0.79"
         },
         "atri-utils": {


### PR DESCRIPTION
Description :

This pull request fixes an issue where the dependency atri could not be installed because the index testpypi was not found. The issue was resolved by changing the index to pypi.

Changes Made :

Changed the index for atri from testpypi to pypi in the Pipfile.lock.